### PR TITLE
Change : by __ in task AzureAppServiceSettings@1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ stages:
               appSettings: |
                 [
                   {
-                    "name": "LeaderboardFunctionUrl",
+                    "name": "AppSettings__LeaderboardFunctionUrl",
                     "value": "http://$(LeaderboardAppName).azurewebsites.net/api/LeaderboardFunction",
                     "slotSetting": false
                   }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,8 +106,10 @@ stages:
               appSettings: |
                 [
                   {
-                    "name": "AppSettings:LeaderboardFunctionUrl",
+                    "name": "LeaderboardFunctionUrl",
                     "value": "http://$(LeaderboardAppName).azurewebsites.net/api/LeaderboardFunction",
                     "slotSetting": false
                   }
                 ]
+          
+          

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ stages:
               appSettings: |
                 [
                   {
-                    "name": "AppSettings_LeaderboardFunctionUrl",
+                    "name": "LeaderboardFunctionUrl",
                     "value": "http://$(LeaderboardAppName).azurewebsites.net/api/LeaderboardFunction",
                     "slotSetting": false
                   }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,10 +106,8 @@ stages:
               appSettings: |
                 [
                   {
-                    "name": "LeaderboardFunctionUrl",
+                    "name": "AppSettings_LeaderboardFunctionUrl",
                     "value": "http://$(LeaderboardAppName).azurewebsites.net/api/LeaderboardFunction",
                     "slotSetting": false
                   }
                 ]
-          
-          


### PR DESCRIPTION
Following the [Automate Azure Functions deployments with Azure Pipelines ](https://docs.microsoft.com/en-us/learn/modules/deploy-azure-functions/) module, when I try to run the pipeline I get the error: ##[error]Error: Failed to update App service 'tailspin-space-game-web-29051' application settings. Error: BadRequest - AppSetting with name 'AppSettings:LeaderboardFunctionUrl' is not allowed. (CODE: 400). Reading a little more in the documentation:
[Configure an App Service app in the Azure portal
](https://docs.microsoft.com/en-us/azure/app-service/configure-common )

![image](https://user-images.githubusercontent.com/14982868/127689033-f1b2d702-ef25-4fa0-815c-1216e687285a.png)

After complete the pipeline I continue with errors but are of the application, I supposed that could be changes like the are mentioned in this pull request: 