### PR TITLE
Fix appSettings parameter. Is a linux App Service plan. We have to us…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ stages:
               appSettings: |
                 [
                   {
-                    "name": "AppSettings:LeaderboardFunctionUrl",
+                    "name": "AppSettings__LeaderboardFunctionUrl",
                     "value": "http://$(LeaderboardAppName).azurewebsites.net/api/LeaderboardFunction",
                     "slotSetting": false
                   }


### PR DESCRIPTION
Following the [Automate Azure Functions deployments with Azure Pipelines](https://docs.microsoft.com/en-us/learn/modules/deploy-azure-functions/) module, when I try to run the pipeline I get the error: ##[error]Error: Failed to update App service 'tailspin-space-game-web-29051' application settings. Error: BadRequest - AppSetting with name 'AppSettings:LeaderboardFunctionUrl' is not allowed. (CODE: 400). Reading a little more in the documentation:

[Configure an App Service app in the Azure portal](https://docs.microsoft.com/en-us/azure/app-service/configure-common)

![image](https://user-images.githubusercontent.com/14982868/127709434-afefa14a-860e-4eed-a50a-e1c6d7eb9966.png)

After complete the pipeline I continue with errors but are of the application, I supposed that could be changes like the are mentioned in this pull request: [MicrosoftDocs/mslearn-tailspin-spacegame-web-kubernetes#7](https://github.com/MicrosoftDocs/mslearn-tailspin-spacegame-web-kubernetes/pull/7)