### PR TITLE
Bump node-sass to 6.0.1 for node16

### DIFF
--- a/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardFunctionClient.cs
+++ b/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardFunctionClient.cs
@@ -21,7 +21,7 @@ namespace TailSpin.SpaceGame.Web
             using (WebClient webClient = new WebClient())
             {
                 string json = await webClient.DownloadStringTaskAsync($"{this._functionUrl}?page={page}&pageSize={pageSize}&mode={mode}&region={region}");
-                return JsonSerializer.Deserialize<LeaderboardResponse>(json);
+                return JsonSerializer.Deserialize<LeaderboardResponse>(json, new JsonSerializerOptions { IncludeFields = true });
             }
         }
     }

--- a/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardResponse.cs
+++ b/Tailspin.SpaceGame.Web/LeaderboardFunctionClient/LeaderboardResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using TailSpin.SpaceGame.Web.Models;
 
 namespace TailSpin.SpaceGame.Web
@@ -6,17 +7,24 @@ namespace TailSpin.SpaceGame.Web
     public class LeaderboardResponse
     {
         // The game mode selected in the view.
+        [JsonPropertyName("selectedMode")]
         public string SelectedMode { get; set; }
+
         // The game region (map) selected in the view.
+        [JsonPropertyName("selectedRegion")]
         public string SelectedRegion { get; set; }
         // The current page to be shown in the view.
+        [JsonPropertyName("page")]
         public int Page { get; set; }
         // The number of items to show per page in the view.
+        [JsonPropertyName("pageSize")]
         public int PageSize { get; set; }
 
         // The scores to display in the view.
+        [JsonPropertyName("scores")]
         public IEnumerable<ScoreProfile> Scores { get; set; }
         // The total number of results for the selected game mode and region in the view.
+        [JsonPropertyName("totalResults")]
         public int TotalResults { get; set; }
     }
 }

--- a/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
+++ b/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
@@ -45,9 +45,9 @@ namespace TailSpin.SpaceGame.Web.Models
     public class ScoreProfile
     {
         [JsonPropertyName("score")]
-        public Score Score { get; set; };
+        public Score Score { get; set; }
         // The player's profile.
         [JsonPropertyName("profile")]
-        public Profile Profile { get; set; };
+        public Profile Profile { get; set; }
     }
 }

--- a/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
+++ b/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace TailSpin.SpaceGame.Web.Models
 {
@@ -43,9 +44,10 @@ namespace TailSpin.SpaceGame.Web.Models
     /// </summary>
     public struct ScoreProfile
     {
-        // The player's score.
+        [JsonPropertyName("score")]
         public Score Score;
         // The player's profile.
+        [JsonPropertyName("profile")]
         public Profile Profile;
     }
 }

--- a/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
+++ b/Tailspin.SpaceGame.Web/Models/LeaderboardViewModel.cs
@@ -42,12 +42,12 @@ namespace TailSpin.SpaceGame.Web.Models
     /// <summary>
     /// Combines a score and a user profile.
     /// </summary>
-    public struct ScoreProfile
+    public class ScoreProfile
     {
         [JsonPropertyName("score")]
-        public Score Score;
+        public Score Score { get; set; };
         // The player's profile.
         [JsonPropertyName("profile")]
-        public Profile Profile;
+        public Profile Profile { get; set; };
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ stages:
               appSettings: |
                 [
                   {
-                    "name": "AppSettings:LeaderboardFunctionUrl",
+                    "name": "LeaderboardFunctionUrl",
                     "value": "http://$(LeaderboardAppName).azurewebsites.net/api/LeaderboardFunction",
                     "slotSetting": false
                   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "gulp-clean-css": "^4.2.0",
     "gulp-concat": "2.6.1",
     "gulp-uglify": "3.0.0",
-    "node-sass": "^4.14.1",
+    "node-sass": "^6.0.1",
     "rimraf": "2.6.1"
   }
 }


### PR DESCRIPTION
node-sass@4.14.1 cannot be installed on node16
https://www.npmjs.com/package/node-sass
![image](https://user-images.githubusercontent.com/4566555/149427432-fb549a7e-7b15-4a98-84b2-f49529c8acc6.png)
